### PR TITLE
Add support for RegExp patterns with named capture groups

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -9,7 +9,9 @@ const routes = [
 	['POST', '/users', '/users'],
 	['GET', '/users/:id', '/users/123'],
 	['PUT', '/users/:id/books/:title?', '/users/123/books'],
-	['DELETE', '/users/:id/books/:title', '/users/123/books/foo']
+	['DELETE', '/users/:id/books/:title', '/users/123/books/foo'],
+	['PATCH', /^[/]users[/](?<id>\d+)[/]?$/, '/users/456'],
+	['OPTIONS', /^[/]users[/](?<id>\d+)[/]books[/](?<title>[^/]+)[/]?$/, '/users/456/books/foo']
 ];
 
 const trouter = new Trouter();

--- a/index.mjs
+++ b/index.mjs
@@ -18,13 +18,13 @@ export default class Trouter {
 
 	use(route, ...fns) {
 		let handlers = [].concat.apply([], fns);
-		let { keys = null, pattern } = route instanceof RegExp ? { pattern: route } : parse(route, true);
+		let { keys, pattern } = parse(route, true);
 		this.routes.push({ keys, pattern, method:'', handlers });
 		return this;
 	}
 
 	add(method, route, ...fns) {
-		let { keys = null, pattern } = route instanceof RegExp ? { pattern: route } : parse(route);
+		let { keys, pattern } = parse(route);
 		let handlers = [].concat.apply([], fns);
 		this.routes.push({ keys, pattern, method, handlers });
 		return this;
@@ -32,19 +32,15 @@ export default class Trouter {
 
 	find(method, url) {
 		let isHEAD=(method === 'HEAD');
-		let i=0, j=0, tmp, arr=this.routes, key;
+		let i=0, j=0, tmp, arr=this.routes;
 		let matches=[], params={}, handlers=[];
 		for (; i < arr.length; i++) {
 			tmp = arr[i];
 			if (tmp.method.length === 0 || tmp.method === method || isHEAD && tmp.method === 'GET') {
-				if (tmp.keys === null || tmp.keys.length > 0) {
+				if (tmp.keys.length > 0) {
 					matches = tmp.pattern.exec(url);
 					if (matches === null) continue;
-					if (tmp.keys === null) {
-						for (key in matches.groups || {}) params[key]=matches.groups[key];
-					} else {
-						for (j=0; j < tmp.keys.length;) params[tmp.keys[j]]=matches[++j];
-					}
+					for (j=0; j < tmp.keys.length;) params[tmp.keys[j]]=matches[++j];
 					tmp.handlers.length > 1 ? (handlers=handlers.concat(tmp.handlers)) : handlers.push(tmp.handlers[0]);
 				} else if (tmp.pattern.test(url)) {
 					tmp.handlers.length > 1 ? (handlers=handlers.concat(tmp.handlers)) : handlers.push(tmp.handlers[0]);

--- a/index.mjs
+++ b/index.mjs
@@ -32,12 +32,17 @@ export default class Trouter {
 
 	find(method, url) {
 		let isHEAD=(method === 'HEAD');
-		let i=0, j=0, tmp, arr=this.routes;
+		let i=0, j=0, k, tmp, arr=this.routes;
 		let matches=[], params={}, handlers=[];
 		for (; i < arr.length; i++) {
 			tmp = arr[i];
 			if (tmp.method.length === 0 || tmp.method === method || isHEAD && tmp.method === 'GET') {
-				if (tmp.keys.length > 0) {
+				if (tmp.keys === false) {
+					matches = tmp.pattern.exec(url);
+					if (matches === null) continue;
+					if (matches.groups !== void 0) for (k in matches.groups) params[k]=matches.groups[k];
+					tmp.handlers.length > 1 ? (handlers=handlers.concat(tmp.handlers)) : handlers.push(tmp.handlers[0]);
+				} else if (tmp.keys.length > 0) {
 					matches = tmp.pattern.exec(url);
 					if (matches === null) continue;
 					for (j=0; j < tmp.keys.length;) params[tmp.keys[j]]=matches[++j];

--- a/index.mjs
+++ b/index.mjs
@@ -18,13 +18,13 @@ export default class Trouter {
 
 	use(route, ...fns) {
 		let handlers = [].concat.apply([], fns);
-		let { keys, pattern } = parse(route, true);
+		let { keys = null, pattern } = route instanceof RegExp ? { pattern: route } : parse(route, true);
 		this.routes.push({ keys, pattern, method:'', handlers });
 		return this;
 	}
 
 	add(method, route, ...fns) {
-		let { keys, pattern } = parse(route);
+		let { keys = null, pattern } = route instanceof RegExp ? { pattern: route } : parse(route);
 		let handlers = [].concat.apply([], fns);
 		this.routes.push({ keys, pattern, method, handlers });
 		return this;
@@ -32,15 +32,19 @@ export default class Trouter {
 
 	find(method, url) {
 		let isHEAD=(method === 'HEAD');
-		let i=0, j=0, tmp, arr=this.routes;
+		let i=0, j=0, tmp, arr=this.routes, key;
 		let matches=[], params={}, handlers=[];
 		for (; i < arr.length; i++) {
 			tmp = arr[i];
 			if (tmp.method.length === 0 || tmp.method === method || isHEAD && tmp.method === 'GET') {
-				if (tmp.keys.length > 0) {
+				if (tmp.keys === null || tmp.keys.length > 0) {
 					matches = tmp.pattern.exec(url);
 					if (matches === null) continue;
-					for (j=0; j < tmp.keys.length;) params[tmp.keys[j]]=matches[++j];
+					if (tmp.keys === null) {
+						for (key in matches.groups || {}) params[key]=matches.groups[key];
+					} else {
+						for (j=0; j < tmp.keys.length;) params[tmp.keys[j]]=matches[++j];
+					}
 					tmp.handlers.length > 1 ? (handlers=handlers.concat(tmp.handlers)) : handlers.push(tmp.handlers[0]);
 				} else if (tmp.pattern.test(url)) {
 					tmp.handlers.length > 1 ? (handlers=handlers.concat(tmp.handlers)) : handlers.push(tmp.handlers[0]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,9 +410,9 @@
       }
     },
     "regexparam": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-1.2.0.tgz",
-      "integrity": "sha512-uSDJXp9qGMcTQpYkzK8xb1qc3n5l7y/bed2GO4fXDiiLcMSUSeUYhrzJirnFte1nd153+krKErlTa0c6nyQoMw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-1.3.0.tgz",
+      "integrity": "sha512-6IQpFBv6e5vz1QAqI+V4k8P2e/3gRrqfCJ9FI+O1FLQTO+Uz6RXZEZOPmTJ6hlGj7gkERzY5BRCv09whKP96/g=="
     },
     "repeat-string": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "routing"
   ],
   "dependencies": {
-    "regexparam": "^1.2.0"
+    "regexparam": "^1.3.0"
   },
   "devDependencies": {
     "bundt": "0.4.0",

--- a/readme.md
+++ b/readme.md
@@ -65,9 +65,11 @@ GET  HEAD  PATCH  OPTIONS  CONNECT  DELETE  TRACE  POST  PUT
 ```
 
 #### pattern
-Type: `String | RegExp`
+Type: `String` or `RegExp`
 
-Trouter supports simple route patterns which are fast and well readable but limited. If you need more complex patterns, you can pass an instance of `RegExp` with parameters specified as named capture groups (supported since Node 10).
+Trouter supports simple route patterns which are fast and well readable but limited. If you need more complex patterns, you can pass an instance of `RegExp` with parameters specified as named capture groups.
+
+> **Important:** RegExp named capture groups are [supported in Node.js 10.x](https://node.green/#ES2018-features--RegExp-named-capture-groups) and above!
 
 The supported route pattern types are:
 

--- a/readme.md
+++ b/readme.md
@@ -65,11 +65,11 @@ GET  HEAD  PATCH  OPTIONS  CONNECT  DELETE  TRACE  POST  PUT
 ```
 
 #### pattern
-Type: `String`
+Type: `String | RegExp`
 
-Unlike most router libraries, Trouter does not use `RegExp` to determine pathname matches. Instead, it uses string comparison which is much faster, but also limits the pattern complexity.
+Trouter supports simple route patterns which are fast and well readable but limited. If you need more complex patterns, you can pass an instance of `RegExp` with parameters specified as named capture groups (supported since Node 10).
 
-The supported pattern types are:
+The supported route pattern types are:
 
 * static (`/users`)
 * named parameters (`/users/:id`)

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import { test, Test } from 'tape';
 import Trouter from '../';
 
-const regexpNamedGroupsSupported = 'groups' in 'x'.match(/x/);
+const hasNamedGroups = 'groups' in 'x'.match(/x/);
 
 const noop = () => {};
 const METHODS = ['GET', 'HEAD', 'PATCH', 'OPTIONS', 'CONNECT', 'DELETE', 'TRACE', 'POST', 'PUT'];
@@ -29,7 +29,7 @@ Object.assign(Test.prototype, {
 			this.isArray(val.keys, '~~> keys is an Array');
 			this.same(val.keys, obj.keys, '~~> keys are expected');
 		} else {
-			this.is(val.keys, null, '~~> keys is null')
+			this.is(val.keys, false, '~~> (RegExp) keys is false')
 		}
 		this.true(val.pattern instanceof RegExp, '~~> pattern is a RegExp');
 		if (obj.route) this.true(val.pattern.test(obj.route), '~~> pattern satisfies route');
@@ -95,7 +95,7 @@ test('add()', t => {
 		count: 1
 	});
 
-	if (regexpNamedGroupsSupported) {
+	if (hasNamedGroups) {
 		console.log(' ');
 		ctx.add('PUT', /^[/]foo[/](?<hello>\w+)[/]?$/, noop);
 		t.is(ctx.routes.length, 3, 'added "PUT /^[/]foo[/](?<hello>\\w+)[/]?$/" route successfully');
@@ -489,7 +489,7 @@ test('find() w/ use()', t => {
 });
 
 
-if (regexpNamedGroupsSupported) {
+if (hasNamedGroups) {
 	test('find() - regex w/ named groups', t => {
 		t.plan(9);
 		const ctx = new Trouter();
@@ -523,7 +523,7 @@ if (regexpNamedGroupsSupported) {
 			new Trouter()
 				.use('/foo', req => {
 					t.pass('~> ran use("/foo")" route'); // x2
-					isRoot || t.is(req.params.title, 'bar', '~~> saw "param.title" value');
+					isRoot || t.is(req.params.title, 'bar', '~~> saw "params.title" value');
 					t.is(req.chain++, 0, '~~> ran 1st');
 				})
 				.get('/foo', req => {

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,8 @@
 import { test, Test } from 'tape';
 import Trouter from '../';
 
+const regexpNamedGroupsSupported = 'groups' in 'x'.match(/x/);
+
 const noop = () => {};
 const METHODS = ['GET', 'HEAD', 'PATCH', 'OPTIONS', 'CONNECT', 'DELETE', 'TRACE', 'POST', 'PUT'];
 
@@ -22,9 +24,13 @@ Object.assign(Test.prototype, {
 	},
 	isRoute(val, obj={}) {
 		this.isObject(val, '~> route definition is an object');
-		this.isArray(val.keys, '~~> keys is an Array');
-		if (obj.keys) this.same(val.keys, obj.keys, '~~> keys are expected');
 
+		if (obj.keys) {
+			this.isArray(val.keys, '~~> keys is an Array');
+			this.same(val.keys, obj.keys, '~~> keys are expected');
+		} else {
+			this.is(val.keys, null, '~~> keys is null')
+		}
 		this.true(val.pattern instanceof RegExp, '~~> pattern is a RegExp');
 		if (obj.route) this.true(val.pattern.test(obj.route), '~~> pattern satisfies route');
 
@@ -88,6 +94,19 @@ test('add()', t => {
 		route: '/bar',
 		count: 1
 	});
+
+	if (regexpNamedGroupsSupported) {
+		console.log(' ');
+		ctx.add('PUT', /^[/]foo[/](?<hello>\w+)[/]?$/, noop);
+		t.is(ctx.routes.length, 3, 'added "PUT /^[/]foo[/](?<hello>\\w+)[/]?$/" route successfully');
+
+		t.isRoute(ctx.routes[2], {
+			keys: null,
+			method: 'PUT',
+			route: '/foo/bar',
+			count: 1
+		});
+	}
 
 	t.end();
 });
@@ -468,3 +487,76 @@ test('find() w/ use()', t => {
 
 	t.end();
 });
+
+
+if (regexpNamedGroupsSupported) {
+	test('find() - regex w/ named groups', t => {
+		t.plan(9);
+		const ctx = new Trouter();
+
+		ctx.get(/^[/]foo[/](?<title>\w+)[/]?$/, req => {
+			t.is(req.chain++, 1, '~> 1st "GET /^[/]foo[/](?<title>\\w+)[/]?$/" ran first');
+			t.is(req.params.title, 'bar', '~> "params.title" is expected');
+		}, req => {
+			t.is(req.chain++, 2, '~> 2nd "GET /^[/]foo[/](?<title>\\w+)[/]?$/" ran second');
+		});
+
+		const out = ctx.find('GET', '/foo/bar');
+
+		t.isObject(out, 'returns an object');
+		t.isObject(out.params, '~> has "params" key (object)');
+		t.is(out.params.title, 'bar', '~~> "params.title" value is correct');
+
+		t.isArray(out.handlers, `~> has "handlers" key (array)`);
+		t.is(out.handlers.length, 2, '~~> saved both handlers');
+
+		out.chain = 1;
+		out.handlers.forEach(fn => fn(out));
+		t.is(out.chain, 3, '~> executes the handler group sequentially');
+	});
+
+
+	test('find() – multiple regex w/ named groups', t => {
+		t.plan(18);
+
+		const ctx = (
+			new Trouter()
+				.use('/foo', req => {
+					t.pass('~> ran use("/foo")" route'); // x2
+					isRoot || t.is(req.params.title, 'bar', '~~> saw "param.title" value');
+					t.is(req.chain++, 0, '~~> ran 1st');
+				})
+				.get('/foo', req => {
+					t.pass('~> ran "GET /foo" route');
+					t.is(req.chain++, 1, '~~> ran 2nd');
+				})
+				.get(/^[/]foo(?:[/](?<title>\w+))?[/]?$/, req => {
+					t.pass('~> ran "GET /^[/]foo[/](?<title>\\w+)?[/]?$/" route'); // x2
+					isRoot || t.is(req.params.title, 'bar', '~~> saw "params.title" value');
+					isRoot ? t.is(req.chain++, 2, '~~> ran 3rd') : t.is(req.chain++, 1, '~~> ran 2nd');
+				})
+				.get(/^[/]foo[/](?<wild>.*)$/, req => {
+					t.pass('~> ran "GET /^[/]foo[/](?<wild>.*)$/" route');
+					t.is(req.params.wild, 'bar', '~~> saw "params.wild" value');
+					t.is(req.params.title, 'bar', '~~> saw "params.title" value');
+					t.is(req.chain++, 2, '~~> ran 3rd');
+				})
+		);
+
+		let isRoot = true;
+		console.log('GET /foo');
+		let foo = ctx.find('GET', '/foo');
+		t.is(foo.handlers.length, 3, 'found 3 handlers');
+
+		foo.chain = 0;
+		foo.handlers.forEach(fn => fn(foo));
+
+		isRoot = false;
+		console.log('GET /foo/bar');
+		let bar = ctx.find('GET', '/foo/bar');
+		t.is(bar.handlers.length, 3, 'found 3 handlers');
+
+		bar.chain = 0;
+		bar.handlers.forEach(fn => fn(bar));
+	});
+}


### PR DESCRIPTION
The support of RegExp patterns with named capture groups will significantly increase flexiblity of Trouter – it will allow to express any complex patterns for the cases where the regexparam patterns are not enough.

I’ve run bench on Node v10.14.2 and this change doesn’t have any provable negative effect on the performance.

It will increase size of index.mjs by ~11 %.

```diff
 Filename         Filesize  (gzip)
-index.js          1.18 kB  519 B 
+index.js          1.33 kB  579 B
-index.mjs         1.17 kB  518 B
+index.mjs         1.32 kB  577 B
```
